### PR TITLE
fix(#3): copy plugin files locally during init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,9 @@ ai_working
 
 # debug log files
 /debug
+
+# Issue Workflow generated settings (project-specific, not tracked)
+/.claude/settings.json
+/.claude/workflow-config.json
+/.claude/git-conventions.md
+/.claude/plugin/

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "issue-workflow",
+  "version": "1.0.0",
+  "description": "GitHub Issue-driven development workflow for Claude Code",
+  "author": {
+    "name": "drillan"
+  },
+  "skills": "../skills/",
+  "commands": "../commands/"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/issue_workflow"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"plugin" = "issue_workflow/plugin"
+
 [tool.ruff]
 target-version = "py313"
 line-length = 100

--- a/src/issue_workflow/cli/commands/init.py
+++ b/src/issue_workflow/cli/commands/init.py
@@ -10,7 +10,6 @@ from issue_workflow.services.github import check_gh_availability
 from issue_workflow.services.preset_loader import PresetLoader, PresetNotFoundError
 from issue_workflow.services.template import (
     TemplateService,
-    check_user_scope_plugin,
     update_settings_json,
 )
 
@@ -19,7 +18,8 @@ app = typer.Typer(
     invoke_without_command=True,
 )
 
-PLUGIN_URL = "github:drillan/issue-workflow#plugin"
+# Local plugin path (relative to project root)
+PLUGIN_PATH = "./.claude/plugin"
 
 # Exit codes
 EXIT_SUCCESS = 0
@@ -127,12 +127,9 @@ def _run_init(language: str | None, non_interactive: bool, force: bool) -> None:
     for path in generated_files:
         ui.print_success(f"Created {path.relative_to(project_dir)}")
 
-    # Update settings.json with plugin
-    if not check_user_scope_plugin(PLUGIN_URL):
-        settings_path = update_settings_json(claude_dir, PLUGIN_URL)
-        ui.print_success(f"Updated {settings_path.relative_to(project_dir)}")
-    else:
-        ui.print_info("Plugin already installed in user scope, skipping project settings")
+    # Update settings.json with local plugin path
+    settings_path = update_settings_json(claude_dir, PLUGIN_PATH)
+    ui.print_success(f"Updated {settings_path.relative_to(project_dir)}")
 
     ui.print_success("Issue Workflow initialized successfully!")
     ui.print_info("Run 'claude' to start Claude Code with the workflow plugin")

--- a/src/issue_workflow/services/template.py
+++ b/src/issue_workflow/services/template.py
@@ -1,10 +1,37 @@
 """Template service for generating config files."""
 
 import json
+import shutil
 from pathlib import Path
 
 from issue_workflow.models.config import WorkflowConfig, WorkflowSettings
 from issue_workflow.models.preset import LanguagePreset
+
+
+def get_plugin_source_dir() -> Path:
+    """Get the source directory for plugin files.
+
+    Returns:
+        Path to the plugin directory bundled with the package.
+        Falls back to project root plugin/ directory during development.
+    """
+    # First, check for bundled plugin (installed package)
+    package_plugin = Path(__file__).parent.parent / "plugin"
+    if package_plugin.exists():
+        return package_plugin
+
+    # Fallback: development mode - look for plugin/ in project root
+    # Walk up from current file to find project root with plugin/
+    current = Path(__file__).parent
+    for _ in range(5):  # Max 5 levels up
+        candidate = current / "plugin"
+        if candidate.exists() and (candidate / "commands").exists():
+            return candidate
+        current = current.parent
+
+    # Last resort: assume project root structure
+    project_root = Path(__file__).parent.parent.parent.parent
+    return project_root / "plugin"
 
 
 class TemplateService:
@@ -69,6 +96,29 @@ class TemplateService:
 
         return target_path
 
+    def copy_plugin(self, target_dir: Path) -> Path:
+        """Copy plugin files to target directory.
+
+        Copies the bundled plugin files (commands, skills, manifest) to .claude/plugin/.
+
+        Args:
+            target_dir: Directory to write plugin to (.claude/)
+
+        Returns:
+            Path to the plugin directory
+        """
+        source_dir = get_plugin_source_dir()
+        plugin_target = target_dir / "plugin"
+
+        # Remove existing plugin directory if exists
+        if plugin_target.exists():
+            shutil.rmtree(plugin_target)
+
+        # Copy entire plugin directory
+        shutil.copytree(source_dir, plugin_target)
+
+        return plugin_target
+
     def generate_all(self, preset: LanguagePreset, target_dir: Path) -> list[Path]:
         """Generate all config files from preset.
 
@@ -82,6 +132,7 @@ class TemplateService:
         generated: list[Path] = []
         generated.append(self.generate_workflow_config(preset, target_dir))
         generated.append(self.generate_git_conventions(target_dir))
+        generated.append(self.copy_plugin(target_dir))
         return generated
 
     def _get_default_git_conventions(self) -> str:

--- a/tests/unit/test_plugin_copy.py
+++ b/tests/unit/test_plugin_copy.py
@@ -1,0 +1,138 @@
+"""Unit tests for plugin copy functionality."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from issue_workflow.services.template import TemplateService
+
+
+class TestPluginCopy:
+    """Tests for plugin copy functionality in TemplateService."""
+
+    @pytest.fixture
+    def template_service(self) -> TemplateService:
+        """Create template service instance."""
+        return TemplateService()
+
+    @pytest.fixture
+    def target_dir(self, tmp_path: Path) -> Path:
+        """Create target .claude directory."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+        return claude_dir
+
+    def test_copy_plugin_creates_plugin_directory(
+        self, template_service: TemplateService, target_dir: Path
+    ) -> None:
+        """Test that copy_plugin creates .claude/plugin directory."""
+        template_service.copy_plugin(target_dir)
+
+        plugin_dir = target_dir / "plugin"
+        assert plugin_dir.exists()
+        assert plugin_dir.is_dir()
+
+    def test_copy_plugin_creates_claude_plugin_manifest(
+        self, template_service: TemplateService, target_dir: Path
+    ) -> None:
+        """Test that copy_plugin creates .claude-plugin/plugin.json."""
+        template_service.copy_plugin(target_dir)
+
+        manifest_path = target_dir / "plugin" / ".claude-plugin" / "plugin.json"
+        assert manifest_path.exists()
+
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["name"] == "issue-workflow"
+        assert "version" in manifest
+        assert "description" in manifest
+
+    def test_copy_plugin_copies_commands(
+        self, template_service: TemplateService, target_dir: Path
+    ) -> None:
+        """Test that copy_plugin copies command files."""
+        template_service.copy_plugin(target_dir)
+
+        commands_dir = target_dir / "plugin" / "commands"
+        assert commands_dir.exists()
+
+        # Check that command files exist
+        expected_commands = [
+            "start-issue.md",
+            "merge-pr.md",
+            "add-worktree.md",
+            "review-pr-comments.md",
+        ]
+        for cmd in expected_commands:
+            assert (commands_dir / cmd).exists(), f"Command {cmd} should exist"
+
+    def test_copy_plugin_copies_skills(
+        self, template_service: TemplateService, target_dir: Path
+    ) -> None:
+        """Test that copy_plugin copies skill directories."""
+        template_service.copy_plugin(target_dir)
+
+        skills_dir = target_dir / "plugin" / "skills"
+        assert skills_dir.exists()
+
+        # Check that skill directories exist with SKILL.md
+        expected_skills = ["tdd-workflow", "code-quality-gate", "issue-reporter", "doc-updater"]
+        for skill in expected_skills:
+            skill_dir = skills_dir / skill
+            assert skill_dir.exists(), f"Skill directory {skill} should exist"
+            assert (skill_dir / "SKILL.md").exists(), f"SKILL.md in {skill} should exist"
+
+    def test_generate_all_includes_plugin_copy(
+        self, template_service: TemplateService, target_dir: Path
+    ) -> None:
+        """Test that generate_all includes plugin copy."""
+        from issue_workflow.services.preset_loader import PresetLoader
+
+        loader = PresetLoader()
+        preset = loader.load("python")
+
+        generated = template_service.generate_all(preset, target_dir)
+
+        # Plugin directory should be in the generated list
+        plugin_dir = target_dir / "plugin"
+        assert plugin_dir in generated or any(str(plugin_dir) in str(p) for p in generated)
+        assert plugin_dir.exists()
+
+
+class TestSettingsJsonLocalPath:
+    """Tests for settings.json with local plugin path."""
+
+    @pytest.fixture
+    def target_dir(self, tmp_path: Path) -> Path:
+        """Create target .claude directory."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True)
+        return claude_dir
+
+    def test_update_settings_json_uses_local_path(self, target_dir: Path) -> None:
+        """Test that settings.json uses local plugin path."""
+        from issue_workflow.services.template import update_settings_json
+
+        # Plugin path should be relative to .claude directory
+        update_settings_json(target_dir, "./.claude/plugin")
+
+        settings_path = target_dir / "settings.json"
+        assert settings_path.exists()
+
+        settings = json.loads(settings_path.read_text())
+        assert "plugins" in settings
+        assert "./.claude/plugin" in settings["plugins"]
+
+    def test_update_settings_json_preserves_existing_plugins(self, target_dir: Path) -> None:
+        """Test that existing plugins are preserved."""
+        from issue_workflow.services.template import update_settings_json
+
+        # Create existing settings with another plugin
+        settings_path = target_dir / "settings.json"
+        settings_path.write_text('{"plugins": ["other-plugin"]}')
+
+        update_settings_json(target_dir, "./.claude/plugin")
+
+        settings = json.loads(settings_path.read_text())
+        assert "other-plugin" in settings["plugins"]
+        assert "./.claude/plugin" in settings["plugins"]


### PR DESCRIPTION
## Summary

- Fix plugin loading by copying files locally instead of referencing GitHub URL
- Add `.claude-plugin/plugin.json` manifest required by Claude Code
- `init` command now copies plugin to `.claude/plugin/` and uses local path in settings.json

Fixes #3

## Test plan

- [x] Run `uv run pytest` - 137 tests passing
- [x] Run quality checks (`ruff check`, `ruff format`, `mypy`)
- [ ] Test `issue-workflow init -l python` in a fresh project
- [ ] Verify `/start-issue` works in Claude Code after init

🤖 Generated with [Claude Code](https://claude.com/claude-code)