### PR TITLE
docs(#17): enhance README with workflow order and plugin integration details

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -54,25 +54,34 @@ issue-workflow init --language python
 
 ## プラグインコマンド（スラッシュコマンド）
 
-Claude Code内で使用するコマンド：
+Claude Code内で使用するコマンド。推奨ワークフロー順に記載：
 
-| コマンド | 説明 |
-|---------|------|
-| `/start-issue <number>` | Issueを読み込み、ブランチを作成し、実装計画を策定 |
-| `/merge-pr <number>` | CIチェック完了を待機後、PRをマージ |
-| `/add-worktree <number>` | Issue用の新規ワークツリーを作成 |
-| `/review-pr-comments [number]` | PRレビューコメントを確認・対応 |
+| # | コマンド | 説明 | 引数 |
+|---|---------|------|------|
+| 1 | `/add-worktree` | Issue用の新規ワークツリーを作成（オプション） | `<issue番号>` |
+| 2 | `/start-issue` | Issueを読み込み、ブランチを作成し、実装計画を策定 | `<issue番号>` |
+| - | `/commit-push-pr` | コミット、プッシュ、PR作成（公式Plugin） | - |
+| - | `/pr-review-toolkit:review-pr` | PRレビュー（公式Plugin） | `<PR番号>` |
+| 3 | `/review-pr-comments` | PRレビューコメントを確認・対応 | `[PR番号]`（省略可） |
+| 4 | `/merge-pr` | CIチェック完了を待機後、PRをマージ | `<PR番号>` |
+
+### 公式Pluginとの連携
+
+本ツールキットは公式Claude Codeプラグインと連携します：
+
+- **commit-commands** - `/commit-push-pr`を提供し、コミット・プッシュ・PR作成を効率化
+- **pr-review-toolkit** - `/pr-review-toolkit:review-pr`を提供し、包括的なPRレビューを実現
 
 ## 自動起動スキル
 
 適切なコンテキストで自動的にトリガーされるスキル：
 
-| スキル | 説明 |
-|-------|------|
-| `tdd-workflow` | TDDワークフロー（Red-Green-Refactorサイクル）を強制 |
-| `code-quality-gate` | コミット前に品質チェックを実行 |
-| `issue-reporter` | Issueに進捗を投稿 |
-| `doc-updater` | ドキュメント更新が必要な変更を検知 |
+| # | スキル | 説明 | 起動タイミング |
+|---|-------|------|---------------|
+| 1 | `tdd-workflow` | TDDワークフロー（Red-Green-Refactorサイクル）を強制 | 実装開始時 |
+| 2 | `code-quality-gate` | コミット前に品質チェックを実行 | コミット前（必須通過） |
+| 3 | `issue-reporter` | Issueに進捗を投稿 | 計画立案時、問題発覚時 |
+| 4 | `doc-updater` | ドキュメント更新が必要な変更を検知 | API変更時（任意） |
 
 ## 言語プリセット
 

--- a/README.md
+++ b/README.md
@@ -54,25 +54,34 @@ After initialization, use Claude Code slash commands to manage your workflow:
 
 ## Plugin Commands (Slash Commands)
 
-Use these commands within Claude Code:
+Use these commands within Claude Code. Listed in recommended workflow order:
 
-| Command | Description |
-|---------|-------------|
-| `/start-issue <number>` | Load Issue, create branch, and develop implementation plan |
-| `/merge-pr <number>` | Wait for CI checks, then merge PR |
-| `/add-worktree <number>` | Create a new worktree for an Issue |
-| `/review-pr-comments [number]` | Review and respond to PR review comments |
+| # | Command | Description | Arguments |
+|---|---------|-------------|-----------|
+| 1 | `/add-worktree` | Create a new worktree for an Issue (optional) | `<issue-number>` |
+| 2 | `/start-issue` | Load Issue, create branch, and develop implementation plan | `<issue-number>` |
+| - | `/commit-push-pr` | Commit, push, and create PR (Official Plugin) | - |
+| - | `/pr-review-toolkit:review-pr` | Review PR (Official Plugin) | `<pr-number>` |
+| 3 | `/review-pr-comments` | Review and respond to PR review comments | `[pr-number]` (optional) |
+| 4 | `/merge-pr` | Wait for CI checks, then merge PR | `<pr-number>` |
+
+### Official Plugin Integration
+
+This toolkit integrates with official Claude Code plugins:
+
+- **commit-commands** - Provides `/commit-push-pr` for streamlined commit, push, and PR creation
+- **pr-review-toolkit** - Provides `/pr-review-toolkit:review-pr` for comprehensive PR reviews
 
 ## Auto-Activated Skills
 
 These skills are automatically triggered during appropriate contexts:
 
-| Skill | Description |
-|-------|-------------|
-| `tdd-workflow` | Enforces TDD workflow (Red-Green-Refactor cycle) |
-| `code-quality-gate` | Runs quality checks before commits |
-| `issue-reporter` | Posts progress updates to Issues |
-| `doc-updater` | Detects changes requiring documentation updates |
+| # | Skill | Description | Activation Timing |
+|---|-------|-------------|-------------------|
+| 1 | `tdd-workflow` | Enforces TDD workflow (Red-Green-Refactor cycle) | Implementation start |
+| 2 | `code-quality-gate` | Runs quality checks before commits | Pre-commit (required to pass) |
+| 3 | `issue-reporter` | Posts progress updates to Issues | Planning phase, problem detection |
+| 4 | `doc-updater` | Detects changes requiring documentation updates | API changes (optional) |
 
 ## Language Presets
 


### PR DESCRIPTION
## Summary
- Reorder plugin commands table to show recommended workflow sequence with numbered steps
- Add arguments column to clarify command usage for each slash command
- Document official plugin integration (commit-commands, pr-review-toolkit)
- Add activation timing column to auto-activated skills table for better clarity
- Update both English and Japanese READMEs for consistency

## Test plan
- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify README.ja.md renders correctly on GitHub
- [ ] Confirm table formatting is correct in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)