### PR TITLE
fix(scripts): remove frontmatter processing that caused no_exec error

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -168,4 +168,27 @@ issueに対応するworktreeを作成します（setup-issue.sh から呼び出�
 - `gh` CLI がインストールされていること
 - `claude` CLI がインストールされていること
 - `jq` がインストールされていること（verboseモードで使用）
+- `issue-workflow` コマンドがインストールされていること（`full-workflow.sh` で使用）
 - GitHubへの認証が完了していること
+
+## 環境変数
+
+| 変数名 | 説明 | デフォルト |
+|--------|------|-----------|
+| `ISSUE_WORKFLOW_LANGUAGE` | 言語プリセット（`full-workflow.sh` で使用） | `generic` |
+
+利用可能な言語プリセット: `python`, `typescript`, `go`, `rust`, `generic`
+
+```bash
+# 例: Pythonプロジェクトでfull-workflowを実行
+ISSUE_WORKFLOW_LANGUAGE=python ./scripts/full-workflow.sh 199
+```
+
+## 共通オプション
+
+すべてのスクリプトは以下の共通オプションをサポートしています:
+
+| オプション | 説明 |
+|-----------|------|
+| `-h`, `--help` | ヘルプを表示 |
+| `-v`, `--verbose` | 途中経過を表示（ツール呼び出しを含む）|

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -26,55 +26,205 @@ lib_get_project_name() {
 }
 
 # ========================================
+# 依存コマンドチェック
+# ========================================
+
+# 必須コマンドの存在確認
+# 引数: コマンド名のリスト
+# 戻り値: 0=すべて存在, 1=不足あり
+lib_check_dependencies() {
+    local missing=()
+    for cmd in "$@"; do
+        if ! command -v "$cmd" &>/dev/null; then
+            missing+=("$cmd")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "⚠️ 必須コマンドが見つかりません: ${missing[*]}" >&2
+        echo "" >&2
+        echo "以下のコマンドをインストールしてください:" >&2
+        for cmd in "${missing[@]}"; do
+            case "$cmd" in
+                gh) echo "  - gh: https://cli.github.com/" >&2 ;;
+                claude) echo "  - claude: https://www.anthropic.com/claude-code" >&2 ;;
+                jq) echo "  - jq: https://jqlang.github.io/jq/" >&2 ;;
+                *) echo "  - $cmd" >&2 ;;
+            esac
+        done
+        return 1
+    fi
+    return 0
+}
+
+# ========================================
 # オプション解析
 # ========================================
 
-# verboseフラグ（デフォルト: false）
+# グローバル変数（オプション解析結果）
 _LIB_VERBOSE=false
+_LIB_SHOW_HELP=false
+_LIB_REMAINING_ARGS=()
 
-# verboseオプションを解析する
-# 出力: evalで評価可能な形式（変数設定 + 残りの引数）
+# オプションを解析する（evalを使わない安全な設計）
+# グローバル変数を直接設定:
+#   - _LIB_VERBOSE: verboseモードかどうか
+#   - _LIB_SHOW_HELP: ヘルプ表示が必要か
+#   - _LIB_REMAINING_ARGS: 残りの引数配列
+#
 # 使用例:
-#   OUTPUT=$(lib_parse_verbose_option "$@")
-#   eval "$OUTPUT"
-#   # これで _LIB_VERBOSE と REMAINING_ARGS が設定される
-#
-# 出力形式:
-#   _LIB_VERBOSE=true; REMAINING_ARGS='arg1 arg2'
-#   または
-#   _LIB_VERBOSE=false; REMAINING_ARGS='arg1 arg2'
-#
-# 注意:
-#   - printf %q を使用してシェルエスケープを適用
-#   - スペースを含む引数は適切にエスケープされる
-#   - シングルクォートやメタ文字も安全に処理される
-lib_parse_verbose_option() {
-    local args=()
-    local verbose_flag=false
+#   lib_parse_options "$@"
+#   if lib_should_show_help; then
+#       lib_show_usage "スクリプト名" "説明" "[引数]"
+#       exit 0
+#   fi
+#   set -- "${_LIB_REMAINING_ARGS[@]}"
+lib_parse_options() {
+    _LIB_VERBOSE=false
+    _LIB_SHOW_HELP=false
+    _LIB_REMAINING_ARGS=()
+
     while [[ $# -gt 0 ]]; do
         case $1 in
             -v|--verbose)
-                verbose_flag=true
+                _LIB_VERBOSE=true
+                shift
+                ;;
+            -h|--help)
+                _LIB_SHOW_HELP=true
                 shift
                 ;;
             *)
-                args+=("$1")
+                _LIB_REMAINING_ARGS+=("$1")
                 shift
                 ;;
         esac
     done
-    # evalで評価可能な形式で出力（printf %qで安全にエスケープ）
-    local remaining_str=""
-    if [[ ${#args[@]} -gt 0 ]]; then
-        remaining_str="${args[*]}"
-    fi
-    # printf %q を使用してコマンドインジェクションを防止
-    printf '_LIB_VERBOSE=%s; REMAINING_ARGS=%q\n' "$verbose_flag" "$remaining_str"
 }
 
 # verboseモードかどうかを確認
 lib_is_verbose() {
     [[ "$_LIB_VERBOSE" == "true" ]]
+}
+
+# ヘルプ表示が必要かどうかを確認
+lib_should_show_help() {
+    [[ "$_LIB_SHOW_HELP" == "true" ]]
+}
+
+# 使用方法を表示
+# 引数:
+#   $1 - スクリプト名
+#   $2 - 説明
+#   $3 - 引数説明（オプション）
+#   $4 - 追加オプション説明（オプション）
+lib_show_usage() {
+    local script_name="$1"
+    local description="$2"
+    local args="${3:-}"
+    local extra_options="${4:-}"
+
+    echo "$description"
+    echo ""
+    echo "使用方法: $script_name [-v|--verbose] [-h|--help] $args"
+    echo ""
+    echo "オプション:"
+    echo "  -v, --verbose  途中経過を表示（ツール呼び出しを含む）"
+    echo "  -h, --help     このヘルプを表示"
+    if [[ -n "$extra_options" ]]; then
+        echo "$extra_options"
+    fi
+}
+
+# 不明なオプションをチェック
+# 引数: 残りの引数の数（期待値）
+# 使用例: lib_check_unknown_options 0  # 引数なしを期待
+#         lib_check_unknown_options 1  # 引数1つを期待
+lib_check_unknown_options() {
+    local expected_args="${1:-0}"
+    local actual_args=${#_LIB_REMAINING_ARGS[@]}
+
+    if [[ $actual_args -gt $expected_args ]]; then
+        local first_unknown="${_LIB_REMAINING_ARGS[$expected_args]}"
+        if [[ "$first_unknown" == -* ]]; then
+            echo "⚠️ 不明なオプション: $first_unknown" >&2
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# ========================================
+# PR検出
+# ========================================
+
+# 現在のブランチに紐づくPR番号を取得
+# 戻り値:
+#   成功時: PR番号を標準出力に出力し、戻り値0
+#   PRなし: 空を出力し、戻り値0
+#   エラー: エラーメッセージを標準エラーに出力し、戻り値1
+lib_get_pr_number() {
+    # ghコマンドの存在確認
+    if ! command -v gh &>/dev/null; then
+        echo "⚠️ ghコマンドが見つかりません。GitHub CLIをインストールしてください。" >&2
+        echo "   https://cli.github.com/" >&2
+        return 1
+    fi
+
+    # GitHub認証の確認
+    if ! gh auth status &>/dev/null; then
+        echo "⚠️ GitHub認証が必要です。以下のコマンドを実行してください:" >&2
+        echo "   gh auth login" >&2
+        return 1
+    fi
+
+    # PR番号を取得（エラーを一時ファイルに保存）
+    local error_file
+    error_file=$(mktemp)
+    local pr_num
+    if pr_num=$(gh pr view --json number --jq '.number' 2>"$error_file"); then
+        rm -f "$error_file"
+        echo "$pr_num"
+        return 0
+    else
+        local error_msg
+        error_msg=$(cat "$error_file")
+        rm -f "$error_file"
+
+        # PRが存在しない場合は空を返す（正常）
+        if [[ "$error_msg" == *"no pull requests found"* ]] || \
+           [[ "$error_msg" == *"Could not resolve"* ]]; then
+            echo ""
+            return 0
+        fi
+
+        # その他のエラー
+        echo "⚠️ PR情報の取得に失敗しました: $error_msg" >&2
+        return 1
+    fi
+}
+
+# PR番号を検出して表示（共通パターン）
+# 成功時: PR_NUM変数を設定
+# 失敗時: エラーメッセージを表示してexit 1
+lib_detect_pr_or_exit() {
+    echo "🔍 現在のブランチからPRを検出中..."
+
+    local pr_num
+    if ! pr_num=$(lib_get_pr_number); then
+        exit 1
+    fi
+
+    if [[ -z "$pr_num" ]]; then
+        echo "⚠️ 現在のブランチに紐づくPRが見つかりません" >&2
+        echo "" >&2
+        echo "先に complete-issue.sh を実行してPRを作成してください。" >&2
+        exit 1
+    fi
+
+    echo "📍 PRを検出: #$pr_num"
+    # グローバル変数として設定
+    PR_NUM="$pr_num"
 }
 
 # ========================================
@@ -89,19 +239,49 @@ lib_is_verbose() {
 #   $1 - プロンプト文字列
 #   $2 - (オプション) "no_exec" を指定するとexecを使わない
 #
+# 戻り値:
+#   成功時: 0
+#   失敗時: claudeコマンドの終了コード
+#
 # 使用例:
 #   lib_run_claude "$PROMPT"
 #   lib_run_claude "$PROMPT" "no_exec"  # 続きの処理がある場合
+#   if ! lib_run_claude "$PROMPT" "no_exec"; then
+#       echo "claudeの実行に失敗しました"
+#       exit 1
+#   fi
 lib_run_claude() {
     local prompt="$1"
     local no_exec="${2:-}"
 
+    # claudeコマンドの存在確認
+    if ! command -v claude &>/dev/null; then
+        echo "⚠️ claudeコマンドが見つかりません。Claude Codeをインストールしてください。" >&2
+        echo "   https://www.anthropic.com/claude-code" >&2
+        return 1
+    fi
+
     if lib_is_verbose; then
+        # jqの存在確認（verboseモードで必要）
+        if ! command -v jq &>/dev/null; then
+            echo "⚠️ jqコマンドが見つかりません。verboseモードにはjqが必要です。" >&2
+            echo "   https://jqlang.github.io/jq/" >&2
+            return 1
+        fi
+
+        # パイプラインの終了コードを取得するためPIPESTATUSを使用
         claude -p "$prompt" --dangerously-skip-permissions --output-format stream-json --verbose 2>&1 | \
-            _lib_format_stream_json || true
+            _lib_format_stream_json
+        local exit_code=${PIPESTATUS[0]}
+        if [[ $exit_code -ne 0 ]]; then
+            echo "⚠️ claudeの実行に失敗しました（終了コード: $exit_code）" >&2
+            return $exit_code
+        fi
+        return 0
     else
         if [[ "$no_exec" == "no_exec" ]]; then
             claude -p "$prompt" --dangerously-skip-permissions
+            return $?
         else
             exec claude -p "$prompt" --dangerously-skip-permissions
         fi
@@ -156,7 +336,9 @@ lib_find_worktree_dir() {
     # 1. project-name-NNN (ゼロパディング形式: issue-workflow-015)
     # 2. project-name-N (ゼロパディングなし形式: issue-workflow-15)
     # 3. project-name-type-N[-title] (ブランチタイプ形式: issue-workflow-feat-15-add-feature)
-    ls "$parent_dir" 2>/dev/null | grep -E "^${project_name}-(${padded_num}$|${issue_num}$|[a-z]+-${issue_num}(-|$))" | head -1 || true
+    local result
+    result=$(ls "$parent_dir" 2>/dev/null | grep -E "^${project_name}-(${padded_num}$|${issue_num}$|[a-z]+-${issue_num}(-|$))" | head -1) || true
+    echo "$result"
 }
 
 # worktreeの完全パスを取得する

--- a/scripts/add-worktree.sh
+++ b/scripts/add-worktree.sh
@@ -1,21 +1,59 @@
 #!/bin/bash
 # add-worktree.sh - issue番号を指定してgit worktreeを追加する
 #
-# Usage: ./scripts/add-worktree.sh <issue番号>
+# Usage: ./scripts/add-worktree.sh [-h|--help] [--debug] <issue番号>
 # Example: ./scripts/add-worktree.sh 141
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 共通ライブラリを読み込む
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+PROJECT_ROOT=$(lib_get_project_root)
 COMMAND_FILE="$PROJECT_ROOT/.claude/commands/add-worktree.md"
+
+# オプション解析（--debugオプションを追加）
+_SHOW_HELP=false
+_DEBUG_MODE=false
+_REMAINING=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            _SHOW_HELP=true
+            shift
+            ;;
+        --debug)
+            _DEBUG_MODE=true
+            shift
+            ;;
+        *)
+            _REMAINING+=("$1")
+            shift
+            ;;
+    esac
+done
+
+set -- "${_REMAINING[@]}"
+
+# ヘルプ表示
+if [[ "$_SHOW_HELP" == "true" ]]; then
+    echo "issue番号を指定してgit worktreeを追加する"
+    echo ""
+    echo "使用方法: add-worktree.sh [-h|--help] [--debug] <issue番号>"
+    echo ""
+    echo "オプション:"
+    echo "  -h, --help  このヘルプを表示"
+    echo "  --debug     プロンプト内容を表示して終了（デバッグ用）"
+    exit 0
+fi
 
 # 引数チェック
 if [[ $# -lt 1 ]]; then
-    echo "⚠️ issue番号が必要です"
-    echo ""
-    echo "使用方法: $0 <issue番号>"
-    echo "例: $0 141"
+    echo "⚠️ issue番号が必要です" >&2
+    echo "" >&2
+    echo "使用方法: $0 [-h|--help] [--debug] <issue番号>" >&2
+    echo "例: $0 141" >&2
     exit 1
 fi
 
@@ -23,13 +61,13 @@ ISSUE_NUM="$1"
 
 # 数値チェック
 if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
-    echo "⚠️ issue番号は数値で指定してください: $ISSUE_NUM"
+    echo "⚠️ issue番号は数値で指定してください: $ISSUE_NUM" >&2
     exit 1
 fi
 
 # コマンドファイルの存在チェック
 if [[ ! -f "$COMMAND_FILE" ]]; then
-    echo "⚠️ コマンドファイルが見つかりません: $COMMAND_FILE"
+    echo "⚠️ コマンドファイルが見つかりません: $COMMAND_FILE" >&2
     exit 1
 fi
 
@@ -43,7 +81,7 @@ PROMPT="以下の指示に従って、issue #${ISSUE_NUM} のワークツリー�
 ${CONTENT_REPLACED}"
 
 # デバッグ: --debug オプションでプロンプト内容を表示
-if [[ "${2:-}" == "--debug" ]]; then
+if [[ "$_DEBUG_MODE" == "true" ]]; then
     echo "=== Generated Prompt ==="
     echo "$PROMPT"
     echo "========================"

--- a/scripts/complete-issue.sh
+++ b/scripts/complete-issue.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 # complete-issue.sh - 実装完了後にcommit, push, PR作成を実行
 #
-# Usage: ./scripts/complete-issue.sh [-v|--verbose]
-#
-# Options:
-#   -v, --verbose  途中経過を表示（ツール呼び出しを含む）
+# Usage: ./scripts/complete-issue.sh [-v|--verbose] [-h|--help]
 #
 # worktreeディレクトリ内で実行してください。
 
@@ -13,19 +10,17 @@ set -euo pipefail
 # 共通ライブラリを読み込む
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-# オプション解析（evalで _LIB_VERBOSE と REMAINING_ARGS を設定）
-OUTPUT=$(lib_parse_verbose_option "$@")
-# 出力形式を検証してからeval
-if [[ ! "$OUTPUT" =~ ^_LIB_VERBOSE=(true|false)\;\ REMAINING_ARGS= ]]; then
-    echo "ERROR: Option parsing failed" >&2
-    exit 1
+# オプション解析
+lib_parse_options "$@"
+
+# ヘルプ表示
+if lib_should_show_help; then
+    lib_show_usage "complete-issue.sh" "実装完了後にcommit, push, PR作成を実行"
+    exit 0
 fi
-eval "$OUTPUT"
-eval set -- "$REMAINING_ARGS"
 
 # 不明なオプションのチェック
-if [[ $# -gt 0 ]]; then
-    echo "⚠️ 不明なオプション: $1"
+if ! lib_check_unknown_options 0; then
     exit 1
 fi
 

--- a/scripts/full-workflow.sh
+++ b/scripts/full-workflow.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # full-workflow.sh - issue対応の全ワークフローを自動実行
 #
-# Usage: ./scripts/full-workflow.sh [-v|--verbose] <issue番号>
+# Usage: ./scripts/full-workflow.sh [-v|--verbose] [-h|--help] <issue番号>
 # Example: ./scripts/full-workflow.sh 199
 # Example: ./scripts/full-workflow.sh -v 199
 #
-# Options:
-#   -v, --verbose  途中経過を表示（ツール呼び出しを含む）
+# 環境変数:
+#   ISSUE_WORKFLOW_LANGUAGE  言語プリセット（デフォルト: generic）
+#                            利用可能: python, typescript, go, rust, generic
 #
 # 以下を順次実行します:
 # 1. worktree作成 + start-issue（計画立案・実装）
@@ -23,30 +24,37 @@ source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT=$(lib_get_project_root)
 
-# オプション解析（evalで _LIB_VERBOSE と REMAINING_ARGS を設定）
-OUTPUT=$(lib_parse_verbose_option "$@")
-# 出力形式を検証してからeval
-if [[ ! "$OUTPUT" =~ ^_LIB_VERBOSE=(true|false)\;\ REMAINING_ARGS= ]]; then
-    echo "ERROR: Option parsing failed" >&2
-    exit 1
+# 言語設定（環境変数から取得、デフォルトはgeneric）
+WORKFLOW_LANGUAGE="${ISSUE_WORKFLOW_LANGUAGE:-generic}"
+
+# オプション解析
+lib_parse_options "$@"
+set -- "${_LIB_REMAINING_ARGS[@]}"
+
+# ヘルプ表示
+if lib_should_show_help; then
+    lib_show_usage "full-workflow.sh" "issue対応の全ワークフローを自動実行" "<issue番号>" \
+"
+環境変数:
+  ISSUE_WORKFLOW_LANGUAGE  言語プリセット（デフォルト: generic）
+                           利用可能: python, typescript, go, rust, generic"
+    exit 0
 fi
-eval "$OUTPUT"
-eval set -- "$REMAINING_ARGS"
 
 ISSUE_NUM="${1:-}"
 
 if [[ -z "$ISSUE_NUM" ]]; then
-    echo "⚠️ issue番号が必要です"
-    echo ""
-    echo "使用方法: $0 [-v|--verbose] <issue番号>"
-    echo "例: $0 199"
-    echo "例: $0 -v 199"
+    echo "⚠️ issue番号が必要です" >&2
+    echo "" >&2
+    echo "使用方法: $0 [-v|--verbose] [-h|--help] <issue番号>" >&2
+    echo "例: $0 199" >&2
+    echo "例: $0 -v 199" >&2
     exit 1
 fi
 
 # 数値チェック
 if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
-    echo "⚠️ issue番号は数値で指定してください: $ISSUE_NUM"
+    echo "⚠️ issue番号は数値で指定してください: $ISSUE_NUM" >&2
     exit 1
 fi
 
@@ -55,11 +63,12 @@ echo "🚀 Full Workflow: issue #${ISSUE_NUM}"
 if lib_is_verbose; then
     echo "   (verbose mode)"
 fi
+echo "   言語プリセット: $WORKFLOW_LANGUAGE"
 echo "═══════════════════════════════════════════════════════════════"
 echo ""
 
 # Step 1: worktree作成または検出
-echo "📦 Step 1/6: worktree準備"
+echo "📦 Step 1/5: worktree準備"
 echo "───────────────────────────────────────────────────────────────"
 
 WORKTREE_PATH=$(lib_get_worktree_path "$ISSUE_NUM")
@@ -73,7 +82,7 @@ else
     WORKTREE_PATH=$(lib_get_worktree_path "$ISSUE_NUM")
 
     if [[ -z "$WORKTREE_PATH" ]]; then
-        echo "⚠️ ワークツリーディレクトリが見つかりません"
+        echo "⚠️ ワークツリーディレクトリが見つかりません" >&2
         exit 1
     fi
 
@@ -84,16 +93,16 @@ cd "$WORKTREE_PATH"
 echo ""
 
 # worktreeに.claude/ディレクトリを初期化
-issue-workflow init -l python
+issue-workflow init -l "$WORKFLOW_LANGUAGE"
 
 # Step 2: start-issue（計画立案・実装）
-echo "📝 Step 2/6: start-issue（計画立案・実装）"
+echo "📝 Step 2/5: start-issue（計画立案・実装）"
 echo "───────────────────────────────────────────────────────────────"
 
 START_ISSUE_FILE="$WORKTREE_PATH/.claude/commands/start-issue.md"
 
 if [[ ! -f "$START_ISSUE_FILE" ]]; then
-    echo "⚠️ start-issue.md が見つかりません: $START_ISSUE_FILE"
+    echo "⚠️ start-issue.md が見つかりません: $START_ISSUE_FILE" >&2
     exit 1
 fi
 
@@ -104,14 +113,17 @@ PROMPT_START="以下の指示に従って、issue #${ISSUE_NUM} の作業を開�
 
 ${CONTENT_REPLACED}"
 
-lib_run_claude "$PROMPT_START" "no_exec"
+if ! lib_run_claude "$PROMPT_START" "no_exec"; then
+    echo "⚠️ start-issue の実行に失敗しました" >&2
+    exit 1
+fi
 
 echo ""
 echo "✅ start-issue 完了"
 echo ""
 
 # Step 3: complete-issue（commit + push + PR作成）
-echo "📤 Step 3/6: complete-issue（commit + push + PR作成）"
+echo "📤 Step 3/5: complete-issue（commit + push + PR作成）"
 echo "───────────────────────────────────────────────────────────────"
 
 PROMPT_COMPLETE="以下のスキルを実行してください:
@@ -120,48 +132,68 @@ PROMPT_COMPLETE="以下のスキルを実行してください:
 
 実装された変更をコミットし、リモートにプッシュして、プルリクエストを作成してください。"
 
-lib_run_claude "$PROMPT_COMPLETE" "no_exec"
+if ! lib_run_claude "$PROMPT_COMPLETE" "no_exec"; then
+    echo "⚠️ complete-issue の実行に失敗しました" >&2
+    exit 1
+fi
 
 echo ""
 echo "✅ complete-issue 完了"
 echo ""
 
-# Step 4: review-pr（PRレビュー + コメント投稿）
-echo "🔍 Step 4/6: review-pr（PRレビュー + コメント投稿）"
+# Step 4: review-pr + respond-comments（PRレビュー + コメント対応）
+echo "🔍 Step 4/5: review-pr + respond-comments"
 echo "───────────────────────────────────────────────────────────────"
 
-PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
+PR_NUM=""
+if ! PR_NUM=$(lib_get_pr_number); then
+    echo "⚠️ PR情報の取得に失敗しました" >&2
+    exit 1
+fi
 
 if [[ -z "$PR_NUM" ]]; then
     echo "⚠️ PRが見つかりません。review-prをスキップします。"
 else
     echo "📍 PRを検出: #$PR_NUM"
 
+    # review-pr
     PROMPT_REVIEW="/pr-review-toolkit:review-pr $PR_NUM PRにコメントしてください"
-    lib_run_claude "$PROMPT_REVIEW" "no_exec"
+    if ! lib_run_claude "$PROMPT_REVIEW" "no_exec"; then
+        echo "⚠️ review-pr の実行に失敗しました" >&2
+        exit 1
+    fi
 
     echo ""
     echo "✅ review-pr 完了"
     echo ""
 
-    # Step 5: respond-comments（レビューコメントに対応）
-    echo "💬 Step 5/6: respond-comments（レビューコメントに対応）"
-    echo "───────────────────────────────────────────────────────────────"
-
+    # respond-comments
+    echo "💬 レビューコメントに対応中..."
     PROMPT_RESPOND="/review-pr-comments $PR_NUM"
-    lib_run_claude "$PROMPT_RESPOND" "no_exec"
+    if ! lib_run_claude "$PROMPT_RESPOND" "no_exec"; then
+        echo "⚠️ respond-comments の実行に失敗しました" >&2
+        exit 1
+    fi
 
     echo ""
     echo "✅ respond-comments 完了"
-    echo ""
+fi
 
-    # Step 6: merge-pr（CI待機 → マージ → 後処理）
-    echo "🔀 Step 6/6: merge-pr（CI待機 → マージ → 後処理）"
-    echo "───────────────────────────────────────────────────────────────"
-    echo "   (CIチェック完了まで待機します)"
+echo ""
 
+# Step 5: merge-pr（CI待機 → マージ → 後処理）
+echo "🔀 Step 5/5: merge-pr（CI待機 → マージ → 後処理）"
+echo "───────────────────────────────────────────────────────────────"
+echo "   (CIチェック完了まで待機します)"
+
+if [[ -z "$PR_NUM" ]]; then
+    echo "⚠️ PRが存在しないためmerge-prをスキップします。"
+else
     PROMPT_MERGE="/merge-pr $PR_NUM"
-    lib_run_claude "$PROMPT_MERGE" "no_exec"
+    if ! lib_run_claude "$PROMPT_MERGE" "no_exec"; then
+        echo "⚠️ merge-pr の実行に失敗しました" >&2
+        exit 1
+    fi
 
     echo ""
     echo "✅ merge-pr 完了"

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 # merge-pr.sh - PRをマージ（CI完了待機 → マージ → 後処理）
 #
-# Usage: ./scripts/merge-pr.sh [-v|--verbose]
-#
-# Options:
-#   -v, --verbose  途中経過を表示（ツール呼び出しを含む）
+# Usage: ./scripts/merge-pr.sh [-v|--verbose] [-h|--help]
 #
 # worktreeディレクトリ内で実行してください。
 # 現在のブランチに紐づくPRを自動検出します。
@@ -20,34 +17,23 @@ set -euo pipefail
 # 共通ライブラリを読み込む
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-# オプション解析（evalで _LIB_VERBOSE と REMAINING_ARGS を設定）
-OUTPUT=$(lib_parse_verbose_option "$@")
-# 出力形式を検証してからeval
-if [[ ! "$OUTPUT" =~ ^_LIB_VERBOSE=(true|false)\;\ REMAINING_ARGS= ]]; then
-    echo "ERROR: Option parsing failed" >&2
-    exit 1
+# オプション解析
+lib_parse_options "$@"
+
+# ヘルプ表示
+if lib_should_show_help; then
+    lib_show_usage "merge-pr.sh" "PRをマージ（CI完了待機 → マージ → 後処理）"
+    exit 0
 fi
-eval "$OUTPUT"
-eval set -- "$REMAINING_ARGS"
 
 # 不明なオプションのチェック
-if [[ $# -gt 0 ]]; then
-    echo "⚠️ 不明なオプション: $1"
+if ! lib_check_unknown_options 0; then
     exit 1
 fi
 
-echo "🔍 現在のブランチからPRを検出中..."
+# PR番号を検出
+lib_detect_pr_or_exit
 
-PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
-
-if [[ -z "$PR_NUM" ]]; then
-    echo "⚠️ 現在のブランチに紐づくPRが見つかりません"
-    echo ""
-    echo "先に complete-issue.sh を実行してPRを作成してください。"
-    exit 1
-fi
-
-echo "📍 PRを検出: #$PR_NUM"
 echo ""
 echo "🔀 merge-pr を実行中..."
 echo "   (CIチェック完了まで待機します)"

--- a/scripts/respond-comments.sh
+++ b/scripts/respond-comments.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 # respond-comments.sh - PRのレビューコメントに対応
 #
-# Usage: ./scripts/respond-comments.sh [-v|--verbose]
-#
-# Options:
-#   -v, --verbose  途中経過を表示（ツール呼び出しを含む）
+# Usage: ./scripts/respond-comments.sh [-v|--verbose] [-h|--help]
 #
 # worktreeディレクトリ内で実行してください。
 # 現在のブランチに紐づくPRを自動検出します。
@@ -14,34 +11,23 @@ set -euo pipefail
 # 共通ライブラリを読み込む
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-# オプション解析（evalで _LIB_VERBOSE と REMAINING_ARGS を設定）
-OUTPUT=$(lib_parse_verbose_option "$@")
-# 出力形式を検証してからeval
-if [[ ! "$OUTPUT" =~ ^_LIB_VERBOSE=(true|false)\;\ REMAINING_ARGS= ]]; then
-    echo "ERROR: Option parsing failed" >&2
-    exit 1
+# オプション解析
+lib_parse_options "$@"
+
+# ヘルプ表示
+if lib_should_show_help; then
+    lib_show_usage "respond-comments.sh" "PRのレビューコメントに対応"
+    exit 0
 fi
-eval "$OUTPUT"
-eval set -- "$REMAINING_ARGS"
 
 # 不明なオプションのチェック
-if [[ $# -gt 0 ]]; then
-    echo "⚠️ 不明なオプション: $1"
+if ! lib_check_unknown_options 0; then
     exit 1
 fi
 
-echo "🔍 現在のブランチからPRを検出中..."
+# PR番号を検出
+lib_detect_pr_or_exit
 
-PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
-
-if [[ -z "$PR_NUM" ]]; then
-    echo "⚠️ 現在のブランチに紐づくPRが見つかりません"
-    echo ""
-    echo "先に complete-issue.sh を実行してPRを作成してください。"
-    exit 1
-fi
-
-echo "📍 PRを検出: #$PR_NUM"
 echo ""
 echo "💬 review-pr-comments を実行中..."
 echo ""

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 # review-pr.sh - PRをレビューしてコメントを投稿
 #
-# Usage: ./scripts/review-pr.sh [-v|--verbose]
-#
-# Options:
-#   -v, --verbose  途中経過を表示（ツール呼び出しを含む）
+# Usage: ./scripts/review-pr.sh [-v|--verbose] [-h|--help]
 #
 # worktreeディレクトリ内で実行してください。
 # 現在のブランチに紐づくPRを自動検出します。
@@ -14,34 +11,23 @@ set -euo pipefail
 # 共通ライブラリを読み込む
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-# オプション解析（evalで _LIB_VERBOSE と REMAINING_ARGS を設定）
-OUTPUT=$(lib_parse_verbose_option "$@")
-# 出力形式を検証してからeval
-if [[ ! "$OUTPUT" =~ ^_LIB_VERBOSE=(true|false)\;\ REMAINING_ARGS= ]]; then
-    echo "ERROR: Option parsing failed" >&2
-    exit 1
+# オプション解析
+lib_parse_options "$@"
+
+# ヘルプ表示
+if lib_should_show_help; then
+    lib_show_usage "review-pr.sh" "PRをレビューしてコメントを投稿"
+    exit 0
 fi
-eval "$OUTPUT"
-eval set -- "$REMAINING_ARGS"
 
 # 不明なオプションのチェック
-if [[ $# -gt 0 ]]; then
-    echo "⚠️ 不明なオプション: $1"
+if ! lib_check_unknown_options 0; then
     exit 1
 fi
 
-echo "🔍 現在のブランチからPRを検出中..."
+# PR番号を検出
+lib_detect_pr_or_exit
 
-PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
-
-if [[ -z "$PR_NUM" ]]; then
-    echo "⚠️ 現在のブランチに紐づくPRが見つかりません"
-    echo ""
-    echo "先に complete-issue.sh を実行してPRを作成してください。"
-    exit 1
-fi
-
-echo "📍 PRを検出: #$PR_NUM"
 echo ""
 echo "🔍 review-pr を実行中..."
 echo ""

--- a/scripts/setup-issue.sh
+++ b/scripts/setup-issue.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # setup-issue.sh - worktree作成 → start-issue実行の複合スクリプト
 #
-# Usage: ./scripts/setup-issue.sh <issue番号>
+# Usage: ./scripts/setup-issue.sh [-v|--verbose] [-h|--help] <issue番号>
 # Example: ./scripts/setup-issue.sh 199
 
 set -euo pipefail
@@ -12,20 +12,29 @@ source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT=$(lib_get_project_root)
 
-# 引数チェック
+# オプション解析
+lib_parse_options "$@"
+set -- "${_LIB_REMAINING_ARGS[@]}"
+
+# ヘルプ表示
+if lib_should_show_help; then
+    lib_show_usage "setup-issue.sh" "worktree作成 → start-issue実行の複合スクリプト" "<issue番号>"
+    exit 0
+fi
+
 ISSUE_NUM="${1:-}"
 
 if [[ -z "$ISSUE_NUM" ]]; then
-    echo "⚠️ issue番号が必要です"
-    echo ""
-    echo "使用方法: $0 <issue番号>"
-    echo "例: $0 199"
+    echo "⚠️ issue番号が必要です" >&2
+    echo "" >&2
+    echo "使用方法: $0 [-v|--verbose] [-h|--help] <issue番号>" >&2
+    echo "例: $0 199" >&2
     exit 1
 fi
 
 # 数値チェック
 if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
-    echo "⚠️ issue番号は数値で指定してください: $ISSUE_NUM"
+    echo "⚠️ issue番号は数値で指定してください: $ISSUE_NUM" >&2
     exit 1
 fi
 
@@ -43,7 +52,7 @@ else
     WORKTREE_PATH=$(lib_get_worktree_path "$ISSUE_NUM")
 
     if [[ -z "$WORKTREE_PATH" ]]; then
-        echo "⚠️ ワークツリーディレクトリが見つかりません"
+        echo "⚠️ ワークツリーディレクトリが見つかりません" >&2
         exit 1
     fi
 
@@ -58,7 +67,7 @@ echo ""
 START_ISSUE_FILE="$WORKTREE_PATH/.claude/commands/start-issue.md"
 
 if [[ ! -f "$START_ISSUE_FILE" ]]; then
-    echo "⚠️ start-issue.md が見つかりません: $START_ISSUE_FILE"
+    echo "⚠️ start-issue.md が見つかりません: $START_ISSUE_FILE" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Fix "no_exec: command not found" error when running scripts with `-v` flag
- Remove AWK-based frontmatter stripping that expected YAML frontmatter in .md files
- Simplify file reading to use `cat` and bash parameter expansion for variable replacement

## Test plan
- [ ] Run `./scripts/full-workflow.sh -v <issue-number>` and verify no errors
- [ ] Run `./scripts/setup-issue.sh <issue-number>` and verify it works
- [ ] Run `./scripts/add-worktree.sh <issue-number>` and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)