### PR TITLE
fix(#20): add YAML frontmatter to skill files for Claude Code compliance

### DIFF
--- a/src/issue_workflow/skills/code-quality-gate/SKILL.md
+++ b/src/issue_workflow/skills/code-quality-gate/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-quality-gate
+description: Ensure complete compliance with code quality standards. Use before commit, before PR creation, or when quality issues are detected.
+---
+
 # Code Quality Gate Skill
 
 Ensure complete compliance with code quality standards.

--- a/src/issue_workflow/skills/doc-updater/SKILL.md
+++ b/src/issue_workflow/skills/doc-updater/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: doc-updater
+description: Detect changes that require documentation updates and suggest/execute updates. Use when code changes may impact documentation, during pre-PR creation checklist, or when explicitly requested.
+---
+
 # doc-updater
 
 Detect changes that require documentation updates and suggest/execute updates.

--- a/src/issue_workflow/skills/issue-reporter/SKILL.md
+++ b/src/issue_workflow/skills/issue-reporter/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: issue-reporter
+description: Automatically report work progress as comments on GitHub Issues. Use upon completion of major milestones, PR creation, merge completion, or when explicitly requested.
+---
+
 # issue-reporter
 
 Automatically report work progress as comments on Issues.

--- a/src/issue_workflow/skills/tdd-workflow/SKILL.md
+++ b/src/issue_workflow/skills/tdd-workflow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tdd-workflow
+description: Enforce TDD workflow and ensure proper execution of the Red-Green-Refactor cycle. Use when starting a new feature implementation, bug fix, or refactoring.
+---
+
 # TDD Workflow Skill
 
 Enforce TDD workflow and ensure proper execution of the Red-Green-Refactor cycle.


### PR DESCRIPTION
## Summary

- Add required YAML frontmatter (`name` and `description` fields) to all SKILL.md files
- Ensures compliance with Claude Code Agent Skills specification

## Changes

| File | Added Frontmatter |
|------|------------------|
| `tdd-workflow/SKILL.md` | `name: tdd-workflow` |
| `code-quality-gate/SKILL.md` | `name: code-quality-gate` |
| `issue-reporter/SKILL.md` | `name: issue-reporter` |
| `doc-updater/SKILL.md` | `name: doc-updater` |

## Test plan

- [x] Verify frontmatter format matches Claude Code specification
- [x] Confirm `name` matches directory name for each skill
- [x] Confirm `description` is under 1024 characters

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)