### PR TITLE
docs(readme): add pr-review-toolkit GitHub Action CI information

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -70,7 +70,7 @@ Claude Code内で使用するコマンド。推奨ワークフロー順に記載
 本ツールキットは公式Claude Codeプラグインと連携します：
 
 - **commit-commands** - `/commit-push-pr`を提供し、コミット・プッシュ・PR作成を効率化
-- **pr-review-toolkit** - `/pr-review-toolkit:review-pr`を提供し、包括的なPRレビューを実現
+- **pr-review-toolkit** - `/pr-review-toolkit:review-pr`を提供し、包括的なPRレビューを実現。[GitHub Action](https://github.com/marketplace/actions/claude-pr-reviewer)としてCI化も可能。
 
 ## 自動起動スキル
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Use these commands within Claude Code. Listed in recommended workflow order:
 This toolkit integrates with official Claude Code plugins:
 
 - **commit-commands** - Provides `/commit-push-pr` for streamlined commit, push, and PR creation
-- **pr-review-toolkit** - Provides `/pr-review-toolkit:review-pr` for comprehensive PR reviews
+- **pr-review-toolkit** - Provides `/pr-review-toolkit:review-pr` for comprehensive PR reviews. Can also be used as a [GitHub Action](https://github.com/marketplace/actions/claude-pr-reviewer) for CI integration.
 
 ## Auto-Activated Skills
 


### PR DESCRIPTION
## Summary
- Add reference to pr-review-toolkit GitHub Action in both README.md and README.ja.md
- Include marketplace link for easy discovery and integration
- Enables users to set up automated PR reviews in their CI workflows

## Test plan
- [ ] Verify links are valid and point to the correct marketplace page
- [ ] Confirm documentation renders correctly in both English and Japanese

🤖 Generated with [Claude Code](https://claude.com/claude-code)