### PR TITLE
fix: sync bundled start-issue.md and add update documentation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -42,6 +42,24 @@ issue-workflow init --language python
 /merge-pr 456         # PR #456をマージ
 ```
 
+## アップデート
+
+新バージョンがリリースされたら、ツールキットを更新しコマンド/スキルを同期：
+
+```bash
+# 1. ツールキットを更新
+uv tool install git+https://github.com/drillan/issue-workflow.git
+
+# 2. プロジェクトのコマンドとスキルを更新
+issue-workflow update
+```
+
+`--dry-run`で変更内容をプレビュー：
+
+```bash
+issue-workflow update --dry-run
+```
+
 ## CLIコマンド
 
 | コマンド | 説明 |
@@ -49,6 +67,8 @@ issue-workflow init --language python
 | `issue-workflow init` | プロジェクトにIssue Workflowを初期化 |
 | `issue-workflow init --language <lang>` | 言語プリセットを指定して初期化 |
 | `issue-workflow init --non-interactive` | 対話プロンプトなしで初期化（CI/CD用） |
+| `issue-workflow update` | コマンドとスキルを最新バージョンに更新 |
+| `issue-workflow update --dry-run` | 変更内容をプレビュー（実際の変更なし） |
 | `issue-workflow --version` | バージョンを表示 |
 | `issue-workflow --help` | ヘルプを表示 |
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ After initialization, use Claude Code slash commands to manage your workflow:
 /merge-pr 456         # Merge PR #456
 ```
 
+## Updating
+
+When a new version is released, update the toolkit and sync commands/skills:
+
+```bash
+# 1. Update the toolkit
+uv tool install git+https://github.com/drillan/issue-workflow.git
+
+# 2. Update commands and skills in your project
+issue-workflow update
+```
+
+Use `--dry-run` to preview changes before applying:
+
+```bash
+issue-workflow update --dry-run
+```
+
 ## CLI Commands
 
 | Command | Description |
@@ -49,6 +67,8 @@ After initialization, use Claude Code slash commands to manage your workflow:
 | `issue-workflow init` | Initialize Issue Workflow in project |
 | `issue-workflow init --language <lang>` | Initialize with language preset |
 | `issue-workflow init --non-interactive` | Initialize without interactive prompts (CI/CD) |
+| `issue-workflow update` | Update commands and skills to latest version |
+| `issue-workflow update --dry-run` | Show what would be updated without making changes |
 | `issue-workflow --version` | Show version |
 | `issue-workflow --help` | Show help |
 

--- a/src/issue_workflow/commands/start-issue.md
+++ b/src/issue_workflow/commands/start-issue.md
@@ -60,13 +60,73 @@ If branch exists, checkout instead of create.
 
 ### Step 4: Plan Implementation
 
-Unless `--force` is specified, enter plan mode and create an implementation plan:
+Unless `--force` is specified, enter plan mode and create an implementation plan.
 
-1. Analyze the issue requirements
-2. Identify affected files
-3. Design test cases (TDD approach)
-4. Create step-by-step implementation plan
-5. Identify potential risks
+First, read the workflow configuration:
+
+```bash
+cat .claude/workflow-config.json
+```
+
+Check `documentation.ddd.enabled` to determine if DDD workflow is active.
+
+#### Phase 1: Analyze Requirements
+
+1. Extract requirements from issue body
+2. Identify acceptance criteria
+3. Clarify any ambiguous requirements with user
+
+#### Phase 2: Identify Impact Scope
+
+1. Identify affected code files
+2. Identify affected documentation using **doc-updater skill** detection patterns:
+
+| Change Type | Documentation Impact |
+|-------------|---------------------|
+| New CLI option | README, `--help` output |
+| API endpoint added/changed | API documentation |
+| Configuration option added | Config guide |
+| Environment variable added | Setup guide |
+| Feature added | Feature documentation |
+
+Target documents are defined in `documentation.paths` from workflow config.
+
+#### Phase 3: Document-Driven Development (DDD)
+
+**Skip this phase if `documentation.ddd.enabled` is false.**
+
+Before implementation, update documentation as specification using **doc-updater skill**:
+
+1. **Draft documentation changes**
+   - Write usage examples for new features
+   - Document expected behavior
+   - Define configuration options
+   - If `documentation.ddd.retcon_writing` is true, write documentation as if the feature already exists
+     - Purpose: Produces clearer, more confident documentation
+     - Example: "Run `--format json`" instead of "will allow users to..."
+
+2. **Update target documents** (from `documentation.paths`):
+   - `README.md` - Usage and examples
+   - `docs/` - Detailed documentation
+   - CLI `--help` text (in code comments)
+   - `CHANGELOG.md` (from `documentation.changelog`) if applicable
+
+3. **Review documentation with user**
+   - Documentation becomes the "contract" for implementation
+
+#### Phase 4: Design Test Cases (TDD Approach)
+
+Based on the documented specification, design test cases using **tdd-workflow skill**:
+
+1. Identify test scenarios from documentation
+2. Define expected inputs and outputs
+3. Consider edge cases documented in Phase 3
+
+#### Phase 5: Create Implementation Plan
+
+1. List tasks in dependency order
+2. Identify potential risks and mitigations
+3. Summarize in table format
 
 ### Step 5: Report to Issue
 
@@ -97,14 +157,18 @@ Post the plan as a comment on the issue using issue-reporter skill:
 ### Requirements
 [Requirements extracted from issue body]
 
-### Implementation Plan
-1. [Step 1]
-2. [Step 2]
-...
+### Documentation Updates (DDD)
+- [ ] [Target document]: [Update description]
+- [ ] [Target document]: [Update description]
 
 ### Test Plan
 - [Test case 1]
 - [Test case 2]
+
+### Implementation Plan
+1. [Step 1]
+2. [Step 2]
+...
 
 ### Verification
 [Verification steps]
@@ -119,3 +183,7 @@ Post the plan as a comment on the issue using issue-reporter skill:
 | gh not authenticated | Display `gh auth login` instruction |
 | Uncommitted changes | Ask user to commit or stash changes |
 | Branch creation failed | Display error details |
+| `workflow-config.json` not found | Display error: "Run `/init` to create configuration." |
+| `documentation` section missing | Treat as DDD disabled, inform user |
+| `documentation.paths` missing or empty | Display warning about no documentation targets |
+| doc-updater/tdd-workflow skill not found | Display error with skill installation guidance |


### PR DESCRIPTION
## Summary

- Sync `src/issue_workflow/commands/start-issue.md` with `.claude/commands/start-issue.md`
  - The bundled version was missing DDD workflow changes from PR #30
  - This caused `issue-workflow update` to not update `start-issue.md` in user projects
- Add "Updating" section to README.md and README.ja.md explaining how to update the toolkit
- Add `update` and `update --dry-run` commands to CLI Commands table

## Test plan

- [ ] Run `uv tool install git+https://github.com/drillan/issue-workflow.git` after merge
- [ ] Run `issue-workflow update` in a project and verify `start-issue.md` gets updated
- [ ] Verify README sections display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)