### PR TITLE
fix: improve null jq output handling in PR creation workflow

### DIFF
--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -90,15 +90,21 @@ Save this number as `ISSUE_NUMBER` for use in Step 6.
 Check if a PR already exists for the current branch:
 
 ```bash
-EXISTING_PR_NUM=$(gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+EXISTING_PR_NUM=$(gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number // empty')
+PR_CHECK_EXIT=$?
 ```
 
-**If `EXISTING_PR_NUM` is not empty (PR exists):**
+**If command failed (`PR_CHECK_EXIT` non-zero):**
+- Report failure with Phase: pr-check
+- Do NOT proceed to PR creation
+- Include the error output in the failure report
+
+**If command succeeded and `EXISTING_PR_NUM` is not empty (PR exists):**
 - Skip Step 6 (PR creation)
 - Report success using "Success (Existing PR)" output format
 - Include the existing PR number in the output
 
-**If `EXISTING_PR_NUM` is empty (no PR exists):**
+**If command succeeded and `EXISTING_PR_NUM` is empty (no PR exists):**
 - Proceed to Step 6 (create new PR)
 
 ### Step 6: Create Pull Request
@@ -196,6 +202,7 @@ Resolution: {WHAT_TO_DO_NEXT}
 | Push rejected | Push | "Remote rejected push. Resolve conflicts and retry." |
 | gh CLI not found | PR | "gh CLI not installed or not in PATH" |
 | PR already exists | PR | Skip PR creation. Report existing PR number. |
+| gh pr list failure | PR Check | "Failed to check existing PRs. Check authentication, network, or API status." |
 | Permission denied | Push/PR | "Permission denied. Check repository access." |
 
 ## Safety Rules (from CLAUDE.md)

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -197,21 +197,22 @@ lib_get_pr_number() {
     # PR番号を取得（エラーを一時ファイルに保存）
     local error_file
     error_file=$(mktemp)
-    # シグナルを受けた場合もクリーンアップ
-    trap 'rm -f "$error_file" 2>/dev/null' RETURN
 
     local pr_output
     if pr_output=$(gh pr list --head "$branch_name" --state open --json number --jq '.[0].number' 2>"$error_file"); then
         # gh pr list はPR未検出時に空配列を返し、jqが "null" を出力する
         if [[ -z "$pr_output" || "$pr_output" == "null" ]]; then
+            rm -f "$error_file"
             echo ""
             return 0
         fi
+        rm -f "$error_file"
         echo "$pr_output"
         return 0
     else
         local error_msg
         error_msg=$(cat "$error_file")
+        rm -f "$error_file"
         echo "⚠️ PR情報の取得に失敗しました: $error_msg" >&2
         return 1
     fi

--- a/src/issue_workflow/agents/pr-creator.md
+++ b/src/issue_workflow/agents/pr-creator.md
@@ -90,15 +90,21 @@ Save this number as `ISSUE_NUMBER` for use in Step 6.
 Check if a PR already exists for the current branch:
 
 ```bash
-EXISTING_PR_NUM=$(gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+EXISTING_PR_NUM=$(gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number // empty')
+PR_CHECK_EXIT=$?
 ```
 
-**If `EXISTING_PR_NUM` is not empty (PR exists):**
+**If command failed (`PR_CHECK_EXIT` non-zero):**
+- Report failure with Phase: pr-check
+- Do NOT proceed to PR creation
+- Include the error output in the failure report
+
+**If command succeeded and `EXISTING_PR_NUM` is not empty (PR exists):**
 - Skip Step 6 (PR creation)
 - Report success using "Success (Existing PR)" output format
 - Include the existing PR number in the output
 
-**If `EXISTING_PR_NUM` is empty (no PR exists):**
+**If command succeeded and `EXISTING_PR_NUM` is empty (no PR exists):**
 - Proceed to Step 6 (create new PR)
 
 ### Step 6: Create Pull Request
@@ -196,6 +202,7 @@ Resolution: {WHAT_TO_DO_NEXT}
 | Push rejected | Push | "Remote rejected push. Resolve conflicts and retry." |
 | gh CLI not found | PR | "gh CLI not installed or not in PATH" |
 | PR already exists | PR | Skip PR creation. Report existing PR number. |
+| gh pr list failure | PR Check | "Failed to check existing PRs. Check authentication, network, or API status." |
 | Permission denied | Push/PR | "Permission denied. Check repository access." |
 
 ## Safety Rules (from CLAUDE.md)


### PR DESCRIPTION
## Summary
- Fixes #75: Improve null jq output handling to properly distinguish between empty results and command failures
- Updates gh pr list command to capture and check exit codes
- Enhances error propagation in lib_get_pr_number() shell function
- Properly manages temporary file cleanup in error scenarios

## Test plan
- Verify PR creation works when no existing PRs exist
- Verify PR creation handles null jq output correctly
- Verify error messages are properly propagated when gh pr list fails
- Test error file cleanup in edge cases

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)