### PR TITLE
fix: add --force flag to start-issue prompt

### DIFF
--- a/src/issue_workflow/cli/commands/run.py
+++ b/src/issue_workflow/cli/commands/run.py
@@ -117,7 +117,7 @@ def _run_workflow(
         ctx,
         "Step 1/4: start-issue",
         "start-issue",
-        f"/start-issue {issue_number}",
+        f"/start-issue {issue_number} --force",
         {"issue_number": issue_number, "worktree": worktree},
         cwd=ctx.cwd_for_skill,
         verbose=verbose,

--- a/src/issue_workflow/cli/commands/start_issue.py
+++ b/src/issue_workflow/cli/commands/start_issue.py
@@ -94,7 +94,7 @@ def _run_start_issue(
     # Execute claude -p
     runner = ClaudeRunner()
     result = runner.run(
-        f"/start-issue {issue_number}",
+        f"/start-issue {issue_number} --force",
         cwd=cwd,
         timeout_seconds=timeout,
         verbose=verbose,

--- a/tests/unit/test_run_command.py
+++ b/tests/unit/test_run_command.py
@@ -106,7 +106,7 @@ class TestRunBasic:
         _run_workflow(issue_number=199, worktree=False, verbose=False, timeout=3600)
 
         first_call = mock_runner.run.call_args_list[0]
-        assert first_call[0][0] == "/start-issue 199"
+        assert first_call[0][0] == "/start-issue 199 --force"
 
     def test_step2_calls_create_pr_prompt(
         self,

--- a/tests/unit/test_start_issue_command.py
+++ b/tests/unit/test_start_issue_command.py
@@ -64,7 +64,7 @@ class TestStartIssueBasic:
 
         mock_runner.run.assert_called_once()
         call_kwargs = mock_runner.run.call_args
-        assert call_kwargs[0][0] == "/start-issue 199"
+        assert call_kwargs[0][0] == "/start-issue 199 --force"
 
     def test_calls_log_execution(
         self, mock_deps: MagicMock, mock_runner: MagicMock, mock_log_execution: MagicMock


### PR DESCRIPTION
## Summary
The start-issue command was missing the --force flag in the Claude prompt, causing it to enter plan mode which is incompatible with non-interactive `claude -p` execution. This fix adds the --force flag to both run and start_issue commands and updates tests accordingly.

Closes #84

## Test plan
- All existing unit tests pass with the updated assertions
- The start-issue command now properly includes --force in the prompt
- The run command's workflow step 1 now includes --force for non-interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)