### PR TITLE
feat: add .gitignore management service for init command

### DIFF
--- a/src/issue_workflow/cli/commands/init.py
+++ b/src/issue_workflow/cli/commands/init.py
@@ -189,10 +189,17 @@ def _run_init(language: str | None, non_interactive: bool, force: bool) -> None:
         raise typer.Exit(EXIT_GENERAL_ERROR) from e
 
     # Add /.issue-workflow/ to .gitignore
-    if ensure_gitignore_entry(project_dir):
-        ui.print_success("Added /.issue-workflow/ to .gitignore")
-    else:
-        ui.print_info("/.issue-workflow/ already in .gitignore")
+    try:
+        if ensure_gitignore_entry(project_dir):
+            ui.print_success("Added /.issue-workflow/ to .gitignore")
+        else:
+            ui.print_info("/.issue-workflow/ already in .gitignore")
+    except OSError as e:
+        ui.print_error(
+            f"Failed to update .gitignore: {e}\n"
+            "Please add '/.issue-workflow/' to .gitignore manually."
+        )
+        raise typer.Exit(EXIT_GENERAL_ERROR) from e
 
     ui.print_success("Issue Workflow initialized successfully!")
     ui.print_info("Run 'claude' to start using the workflow commands")

--- a/src/issue_workflow/services/gitignore.py
+++ b/src/issue_workflow/services/gitignore.py
@@ -32,9 +32,8 @@ def ensure_gitignore_entry(project_dir: Path) -> bool:
             content += "\n"
 
         content += f"\n{GITIGNORE_SECTION_COMMENT}\n{GITIGNORE_ENTRY}\n"
-        gitignore_path.write_text(content)
     else:
         content = f"{GITIGNORE_SECTION_COMMENT}\n{GITIGNORE_ENTRY}\n"
-        gitignore_path.write_text(content)
 
+    gitignore_path.write_text(content)
     return True

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,34 @@
+"""Shared fixtures for integration tests."""
+
+import os
+import subprocess
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def temp_project(tmp_path: Path) -> Generator[Path]:
+    """Create a temporary project directory with git init."""
+    project_dir = tmp_path / "test-project"
+    project_dir.mkdir()
+
+    subprocess.run(["git", "init"], cwd=project_dir, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=project_dir,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=project_dir,
+        capture_output=True,
+        check=True,
+    )
+
+    original_dir = Path.cwd()
+    os.chdir(project_dir)
+    yield project_dir
+    os.chdir(original_dir)

--- a/tests/integration/test_init_command.py
+++ b/tests/integration/test_init_command.py
@@ -1,9 +1,6 @@
 """Integration tests for init command."""
 
 import json
-import os
-import subprocess
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,33 +12,6 @@ runner = CliRunner()
 
 class TestInitCommand:
     """Tests for issue-workflow init command."""
-
-    @pytest.fixture
-    def temp_project(self, tmp_path: Path) -> Generator[Path]:
-        """Create a temporary project directory."""
-        project_dir = tmp_path / "test-project"
-        project_dir.mkdir()
-
-        # Initialize as git repo
-        subprocess.run(["git", "init"], cwd=project_dir, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "test@example.com"],
-            cwd=project_dir,
-            capture_output=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"],
-            cwd=project_dir,
-            capture_output=True,
-            check=True,
-        )
-
-        # Change to project directory
-        original_dir = Path.cwd()
-        os.chdir(project_dir)
-        yield project_dir
-        os.chdir(original_dir)
 
     def test_init_with_python_preset(self, temp_project: Path) -> None:
         """Test init command with Python preset."""
@@ -179,31 +149,6 @@ class TestInitCommand:
 class TestInitHachimokuSetup:
     """Tests for hachimoku setup during init (T084)."""
 
-    @pytest.fixture
-    def temp_project(self, tmp_path: Path) -> Generator[Path]:
-        """Create a temporary project directory."""
-        project_dir = tmp_path / "test-project"
-        project_dir.mkdir()
-
-        subprocess.run(["git", "init"], cwd=project_dir, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "test@example.com"],
-            cwd=project_dir,
-            capture_output=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"],
-            cwd=project_dir,
-            capture_output=True,
-            check=True,
-        )
-
-        original_dir = Path.cwd()
-        os.chdir(project_dir)
-        yield project_dir
-        os.chdir(original_dir)
-
     def test_init_calls_setup_hachimoku(self, temp_project: Path) -> None:
         """Test that init command calls setup_hachimoku (T084)."""
         from issue_workflow.cli.main import app
@@ -267,31 +212,6 @@ class TestInitHachimokuSetup:
 
 class TestInitGitignoreSetup:
     """Tests for .gitignore setup during init (#92)."""
-
-    @pytest.fixture
-    def temp_project(self, tmp_path: Path) -> Generator[Path]:
-        """Create a temporary project directory."""
-        project_dir = tmp_path / "test-project"
-        project_dir.mkdir()
-
-        subprocess.run(["git", "init"], cwd=project_dir, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "test@example.com"],
-            cwd=project_dir,
-            capture_output=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"],
-            cwd=project_dir,
-            capture_output=True,
-            check=True,
-        )
-
-        original_dir = Path.cwd()
-        os.chdir(project_dir)
-        yield project_dir
-        os.chdir(original_dir)
 
     def test_init_adds_issue_workflow_to_gitignore(self, temp_project: Path) -> None:
         """Test that init adds /.issue-workflow/ to .gitignore (#92)."""

--- a/tests/unit/test_gitignore.py
+++ b/tests/unit/test_gitignore.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from issue_workflow.services.gitignore import ensure_gitignore_entry
 
 GITIGNORE_ENTRY = "/.issue-workflow/"
-GITIGNORE_COMMENT = "# issue-workflow"
+GITIGNORE_SECTION_COMMENT = "# issue-workflow"
 
 
 class TestEnsureGitignoreEntry:
@@ -31,7 +31,7 @@ class TestEnsureGitignoreEntry:
         ensure_gitignore_entry(tmp_path)
 
         content = (tmp_path / ".gitignore").read_text()
-        assert GITIGNORE_COMMENT in content
+        assert GITIGNORE_SECTION_COMMENT in content
 
     def test_appends_to_existing_gitignore(self, tmp_path: Path) -> None:
         """Test entry is appended to existing .gitignore."""
@@ -71,7 +71,7 @@ class TestEnsureGitignoreEntry:
     def test_skips_when_entry_with_comment_already_exists(self, tmp_path: Path) -> None:
         """Test skips when full block (comment + entry) already present."""
         gitignore = tmp_path / ".gitignore"
-        gitignore.write_text(f"node_modules/\n{GITIGNORE_COMMENT}\n{GITIGNORE_ENTRY}\n")
+        gitignore.write_text(f"node_modules/\n{GITIGNORE_SECTION_COMMENT}\n{GITIGNORE_ENTRY}\n")
 
         result = ensure_gitignore_entry(tmp_path)
 


### PR DESCRIPTION
## Summary
- Add new gitignore service module to manage /.issue-workflow/ entry in .gitignore
- Integrate gitignore management into init command during project initialization
- Includes comprehensive unit tests for gitignore handling logic
- Includes integration tests verifying gitignore setup during init

Closes #92

## Test plan
- [x] Unit tests for ensure_gitignore_entry function (create, append, deduplication)
- [x] Integration tests for init command gitignore output
- [x] Manual verification that /.issue-workflow/ is added to .gitignore on init
- [x] Code quality checks passed (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)