### PR TITLE
Enable --force flag to skip TDD confirmations

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -13,7 +13,7 @@ Load a GitHub Issue, create a branch, and develop an implementation plan.
 | Argument | Type | Required | Description |
 |----------|------|----------|-------------|
 | `issue-number` | integer | Yes | GitHub Issue number |
-| `--force` | flag | No | Start implementation without confirmation |
+| `--force` | flag | No | Skip plan mode and all interactive confirmations (including TDD user approval) |
 | `--current-branch` | flag | No | Skip branch creation, use the current branch |
 
 ## Instructions

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -78,7 +78,9 @@ If branch exists, checkout instead of create.
 
 ### Step 4: Plan Implementation
 
-Unless `--force` is specified, enter plan mode and create an implementation plan.
+Unless `--force` is specified, enter plan mode before proceeding. With `--force`, execute all phases directly without entering plan mode and without interactive confirmations.
+
+Regardless of `--force`, execute the following phases to create an implementation plan.
 
 First, read the workflow configuration:
 

--- a/src/issue_workflow/cli/commands/start_issue.py
+++ b/src/issue_workflow/cli/commands/start_issue.py
@@ -65,6 +65,9 @@ def _run_start_issue(
 ) -> int:
     """Execute the start-issue command logic.
 
+    Always invokes the skill with --force to skip plan mode and
+    interactive confirmations (including TDD user approval).
+
     Args:
         issue_number: GitHub Issue number.
         worktree: Whether to use worktree.
@@ -135,7 +138,8 @@ def start_issue(
 ) -> None:
     """Start working on a GitHub Issue.
 
-    Executes the /start-issue skill via claude -p.
+    Executes the /start-issue skill via claude -p with --force, which skips
+    plan mode and all interactive confirmations (including TDD user approval).
 
     \u26a0\ufe0f  Security: This command uses --dangerously-skip-permissions to bypass
     Claude Code's permission checks for automated execution. Only run in

--- a/src/issue_workflow/skills/start-issue/SKILL.md
+++ b/src/issue_workflow/skills/start-issue/SKILL.md
@@ -78,7 +78,9 @@ If branch exists, checkout instead of create.
 
 ### Step 4: Plan Implementation
 
-Unless `--force` is specified, enter plan mode and create an implementation plan.
+Unless `--force` is specified, enter plan mode before proceeding. With `--force`, execute all phases directly without entering plan mode and without interactive confirmations.
+
+Regardless of `--force`, execute the following phases to create an implementation plan.
 
 First, read the workflow configuration:
 

--- a/tests/unit/test_force_flag_skill.py
+++ b/tests/unit/test_force_flag_skill.py
@@ -5,6 +5,7 @@ properly covers TDD user confirmation skipping (Issue #93).
 """
 
 import re
+from pathlib import Path
 
 from issue_workflow.services.template import get_skills_source_dir
 
@@ -12,75 +13,55 @@ from issue_workflow.services.template import get_skills_source_dir
 class TestStartIssueForceFlag:
     """Tests that --force flag in start-issue SKILL.md skips TDD confirmations."""
 
-    def _read_skill(self, skill_name: str) -> str:
-        """Read the SKILL.md content for a given skill."""
-        skill_path = get_skills_source_dir() / skill_name / "SKILL.md"
-        return skill_path.read_text()
-
-    def _extract_phase4_section(self, content: str) -> str:
-        """Extract Phase 4 (TDD) section from SKILL.md content."""
-        # Find Phase 4 header and extract until Phase 5 or next ### header
+    def setup_method(self) -> None:
+        """Read SKILL.md and extract Phase 4 section once per test."""
+        skill_path = get_skills_source_dir() / "start-issue" / "SKILL.md"
+        self.content = skill_path.read_text()
         phase4_match = re.search(
             r"(#### Phase 4.*?)(?=#### Phase 5|### Step 5|\Z)",
-            content,
+            self.content,
             re.DOTALL,
         )
-        if phase4_match:
-            return phase4_match.group(1)
-        return ""
+        self.phase4 = phase4_match.group(1) if phase4_match else ""
+        self.lower_phase4 = self.phase4.lower()
 
     def test_phase4_has_force_flag_instructions(self) -> None:
         """Phase 4 (TDD) must contain --force specific instructions."""
-        content = self._read_skill("start-issue")
-        phase4 = self._extract_phase4_section(content)
-
-        assert phase4, "Phase 4 section must exist in start-issue SKILL.md"
-        assert "force" in phase4.lower(), "Phase 4 (TDD) section must contain --force instructions"
+        assert self.phase4, "Phase 4 section must exist in start-issue SKILL.md"
+        assert "force" in self.lower_phase4, (
+            "Phase 4 (TDD) section must contain --force instructions"
+        )
 
     def test_force_flag_skips_tdd_user_approval(self) -> None:
         """--force must skip TDD user approval/confirmation within Phase 4."""
-        content = self._read_skill("start-issue")
-        phase4 = self._extract_phase4_section(content)
-
-        lower_phase4 = phase4.lower()
-        # Phase 4 must have a conditional about --force skipping user approval
         has_skip_approval = (
-            "force" in lower_phase4
-            and ("skip" in lower_phase4 or "without" in lower_phase4)
+            "force" in self.lower_phase4
+            and ("skip" in self.lower_phase4 or "without" in self.lower_phase4)
             and (
-                "user approval" in lower_phase4
-                or "user confirmation" in lower_phase4
-                or "confirmation" in lower_phase4
+                "user approval" in self.lower_phase4
+                or "user confirmation" in self.lower_phase4
+                or "confirmation" in self.lower_phase4
             )
         )
         assert has_skip_approval, "Phase 4 must state that --force skips user approval/confirmation"
 
     def test_force_flag_enables_autonomous_tdd_cycle(self) -> None:
         """--force must enable autonomous Red-Green-Refactor in Phase 4."""
-        content = self._read_skill("start-issue")
-        phase4 = self._extract_phase4_section(content)
-
-        lower_phase4 = phase4.lower()
-        has_autonomous = "force" in lower_phase4 and (
-            "autonomous" in lower_phase4
-            or "automatically" in lower_phase4
-            or "without confirmation" in lower_phase4
-            or "without user" in lower_phase4
+        has_autonomous = "force" in self.lower_phase4 and (
+            "autonomous" in self.lower_phase4
+            or "automatically" in self.lower_phase4
+            or "without confirmation" in self.lower_phase4
+            or "without user" in self.lower_phase4
         )
         assert has_autonomous, "Phase 4 must instruct autonomous TDD cycle completion with --force"
 
     def test_default_flow_preserves_user_confirmation(self) -> None:
         """Default flow (without --force) must preserve user confirmation."""
-        content = self._read_skill("start-issue")
-        phase4 = self._extract_phase4_section(content)
-
-        lower_phase4 = phase4.lower()
-        # Default flow must still mention user approval/confirmation
         has_default_confirmation = (
-            "user approval" in lower_phase4
-            or "user confirmation" in lower_phase4
-            or "get approval" in lower_phase4
-            or "ask" in lower_phase4
+            "user approval" in self.lower_phase4
+            or "user confirmation" in self.lower_phase4
+            or "get approval" in self.lower_phase4
+            or "ask" in self.lower_phase4
         )
         assert has_default_confirmation, (
             "Phase 4 must preserve user confirmation requirement in default flow"
@@ -88,8 +69,7 @@ class TestStartIssueForceFlag:
 
     def test_force_flag_description_in_arguments_table(self) -> None:
         """The --force description in Arguments table must reflect TDD skip."""
-        content = self._read_skill("start-issue")
-        lines = content.split("\n")
+        lines = self.content.split("\n")
         force_line = None
         for line in lines:
             if "`--force`" in line and "|" in line:
@@ -98,7 +78,6 @@ class TestStartIssueForceFlag:
 
         assert force_line is not None, "--force must be in the Arguments table"
         force_desc = force_line.lower()
-        # Description should mention confirmation/interactive skipping (not just plan)
         has_broader_desc = (
             "confirmation" in force_desc
             or "interactive" in force_desc
@@ -107,4 +86,15 @@ class TestStartIssueForceFlag:
         assert has_broader_desc, (
             "--force description must mention confirmation/interactive skipping, "
             f"not just plan mode. Got: {force_line}"
+        )
+
+    def test_source_and_deployed_skill_md_are_in_sync(self) -> None:
+        """Source and deployed SKILL.md copies must be identical."""
+        deployed_path = Path(".claude/skills/start-issue/SKILL.md")
+        assert deployed_path.exists(), "Deployed SKILL.md must exist at .claude/skills/start-issue/"
+
+        source_path = get_skills_source_dir() / "start-issue" / "SKILL.md"
+        assert source_path.read_text() == deployed_path.read_text(), (
+            "Source and deployed SKILL.md copies have diverged. "
+            "Update both files or run the copy command to sync."
         )


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for --force flag in start-issue skill
- Implement test coverage validating TDD skip behavior
- Enable non-interactive mode to bypass user confirmations for Phase 4 (TDD confirmation)

Closes #93

## Test plan
- Verify tests pass: `pytest tests/unit/test_force_flag_skill.py`
- Verify ruff checks pass: `ruff check --fix . && ruff format . && mypy .`
- Manual testing: Run start-issue with --force flag to confirm TDD prompts are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)