### PR TITLE
fix: enable real-time output streaming for 8moku

### DIFF
--- a/src/issue_workflow/cli/commands/run.py
+++ b/src/issue_workflow/cli/commands/run.py
@@ -153,8 +153,6 @@ def _run_workflow(
     try:
         hachimoku_result = subprocess.run(
             ["8moku", str(pr_number)],
-            capture_output=True,
-            text=True,
             check=False,
             timeout=timeout,
         )
@@ -166,11 +164,6 @@ def _run_workflow(
         ui.print_error(f"Failed to execute 8moku: {e}")
         _print_failure("review (hachimoku)")
         return 1
-
-    if hachimoku_result.stdout:
-        ui.console.print(hachimoku_result.stdout.rstrip())
-    if hachimoku_result.stderr:
-        ui.console.print(hachimoku_result.stderr.rstrip())
 
     ui.console.print(
         f"\\[{COMMAND_NAME}] Step 3/4: review (hachimoku) Done. "

--- a/tests/unit/test_run_command.py
+++ b/tests/unit/test_run_command.py
@@ -52,7 +52,7 @@ def mock_pr_detector() -> Iterator[MagicMock]:
 def mock_subprocess() -> Iterator[MagicMock]:
     """Mock subprocess.run for 8moku execution (returncode=0)."""
     with patch(f"{_MOD}.subprocess.run") as m:
-        m.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        m.return_value = MagicMock(returncode=0)
         yield m
 
 
@@ -146,6 +146,23 @@ class TestRunBasic:
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args[0][0]
         assert call_args == ["8moku", "300"]
+
+    def test_step3a_does_not_capture_output(
+        self,
+        all_mocks: None,
+        mock_subprocess: MagicMock,
+    ) -> None:
+        """8moku subprocess.run must NOT use capture_output so output streams in real-time."""
+        from issue_workflow.cli.commands.run import _run_workflow
+
+        _run_workflow(issue_number=199, worktree=False, verbose=False, timeout=3600)
+
+        mock_subprocess.assert_called_once()
+        call_kwargs = mock_subprocess.call_args.kwargs
+        assert "capture_output" not in call_kwargs
+        assert "text" not in call_kwargs
+        assert "stdout" not in call_kwargs
+        assert "stderr" not in call_kwargs
 
     def test_step3b_calls_respond_review_prompt(
         self,
@@ -329,7 +346,7 @@ class TestRunStepFailure:
     ) -> None:
         """8moku non-zero exit code (findings) continues to respond-review."""
         with patch(f"{_MOD}.subprocess.run") as mock_sub:
-            mock_sub.return_value = MagicMock(returncode=2, stdout="Found 2 issues", stderr="")
+            mock_sub.return_value = MagicMock(returncode=2)
 
             from issue_workflow.cli.commands.run import _run_workflow
 


### PR DESCRIPTION
## Summary
Remove `capture_output=True` and `text=True` from the 8moku subprocess call to allow output to stream in real-time to the console instead of being buffered. Also removes the manual stdout/stderr printing logic that is no longer needed.

Closes #96

## Test plan
- Verify that 8moku output appears in real-time during `run` command execution
- Confirm that existing tests pass with the updated mock (no stdout/stderr attributes)
- Check that exit codes are still properly captured for the respond-review workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)