### PR TITLE
docs: README にバージョン指定インストール方法を追記する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,14 @@ GitHub Issue駆動開発ワークフローツールキット for Claude Code。I
 uv tool install git+https://github.com/drillan/issue-workflow.git
 ```
 
+### 特定バージョンのインストール
+
+特定のバージョンをインストールする場合はタグを指定:
+
+```bash
+uv tool install git+https://github.com/drillan/issue-workflow@v0.1.1
+```
+
 ## クイックスタート
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ GitHub Issue-driven development workflow toolkit for Claude Code. Automates and 
 uv tool install git+https://github.com/drillan/issue-workflow.git
 ```
 
+### Installing a Specific Version
+
+To install a specific version, specify the tag:
+
+```bash
+uv tool install git+https://github.com/drillan/issue-workflow@v0.1.1
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- README.md に「Installing a Specific Version」セクションを追加
- README.ja.md に「特定バージョンのインストール」セクションを追加
- タグを指定してインストールする方法を明示（例: v0.1.1）

Closes #100

## Test plan
- README.md と README.ja.md の両ファイルに新しいセクションが正しく追加されていることを確認
- インストールコマンドの構文が正確であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)