### PR TITLE
fix: add timeout handling to review-pr 8moku subprocess

### DIFF
--- a/src/issue_workflow/cli/commands/review_pr.py
+++ b/src/issue_workflow/cli/commands/review_pr.py
@@ -74,7 +74,12 @@ def _run_review_pr(
             hachimoku_result = subprocess.run(
                 ["8moku", str(resolved_pr)],
                 check=False,
+                timeout=timeout,
             )
+        except subprocess.TimeoutExpired:
+            ui.print_error(f"8moku timed out after {timeout} seconds")
+            ui.console.print("\\[review-pr] Done. (exit_code=1)")
+            return 1
         except OSError as e:
             ui.print_error(f"Failed to execute 8moku: {e}")
             ui.console.print("\\[review-pr] Done. (exit_code=1)")

--- a/tests/unit/test_review_pr_command.py
+++ b/tests/unit/test_review_pr_command.py
@@ -760,6 +760,82 @@ class TestReviewPrTimeout:
         call_kwargs = mock_runner.run.call_args
         assert call_kwargs.kwargs.get("timeout_seconds") == 3600
 
+    def test_timeout_passed_to_8moku_subprocess(
+        self,
+        mock_deps: MagicMock,
+        mock_runner: MagicMock,
+        mock_log_execution: MagicMock,
+        mock_pr_detector: MagicMock,
+        mock_subprocess: MagicMock,
+    ) -> None:
+        """--timeout value is forwarded to 8moku subprocess.run."""
+        from issue_workflow.cli.commands.review_pr import _run_review_pr
+
+        _run_review_pr(
+            pr_number=300,
+            review_only=False,
+            respond_only=False,
+            verbose=False,
+            timeout=600,
+        )
+
+        call_kwargs = mock_subprocess.call_args
+        assert call_kwargs.kwargs.get("timeout") == 600
+
+    def test_8moku_timeout_expired_returns_1(
+        self,
+        mock_deps: MagicMock,
+        mock_runner: MagicMock,
+        mock_log_execution: MagicMock,
+        mock_pr_detector: MagicMock,
+        mock_subprocess: MagicMock,
+    ) -> None:
+        """subprocess.TimeoutExpired from 8moku returns exit_code=1."""
+        import subprocess
+
+        mock_subprocess.side_effect = subprocess.TimeoutExpired(cmd=["8moku", "300"], timeout=600)
+
+        with patch(f"{_MOD}.ui") as mock_ui:
+            from issue_workflow.cli.commands.review_pr import _run_review_pr
+
+            exit_code = _run_review_pr(
+                pr_number=300,
+                review_only=False,
+                respond_only=False,
+                verbose=False,
+                timeout=600,
+            )
+
+            assert exit_code == 1
+            error_calls = [str(c) for c in mock_ui.print_error.call_args_list]
+            assert any("timed out" in c and "600" in c for c in error_calls)
+
+    def test_8moku_timeout_expired_skips_respond_review(
+        self,
+        mock_deps: MagicMock,
+        mock_runner: MagicMock,
+        mock_log_execution: MagicMock,
+        mock_pr_detector: MagicMock,
+        mock_subprocess: MagicMock,
+    ) -> None:
+        """When 8moku times out, respond-review is not executed."""
+        import subprocess
+
+        mock_subprocess.side_effect = subprocess.TimeoutExpired(cmd=["8moku", "300"], timeout=600)
+
+        with patch(f"{_MOD}.ui"):
+            from issue_workflow.cli.commands.review_pr import _run_review_pr
+
+            _run_review_pr(
+                pr_number=300,
+                review_only=False,
+                respond_only=False,
+                verbose=False,
+                timeout=600,
+            )
+
+            mock_runner.run.assert_not_called()
+
 
 class TestReviewPrLogArgs:
     """Tests for log_execution call arguments."""


### PR DESCRIPTION
## Summary
- Pass timeout parameter to subprocess.run for 8moku subprocess
- Explicitly catch subprocess.TimeoutExpired to prevent hangs during PR reviews
- Add comprehensive tests for timeout scenario (3 new test cases)

Closes #109

## Test plan
- [x] Unit tests verify timeout is passed to subprocess.run
- [x] Unit tests verify TimeoutExpired exception returns exit code 1
- [x] Unit tests verify respond-review is skipped on timeout
- [x] All existing tests pass
- [x] Code quality checks pass (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)