### PR TITLE
fix: prevent deadlock in verbose mode by using DEVNULL for stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `_run_verbose()` deadlock risk from unread `stderr=subprocess.PIPE` (#110)
 - `AskUserQuestion` tool disallowed in non-interactive mode
 - PR creation incorrectly skipped when merged/closed PRs exist for same branch
 - Error suppression patterns replaced with explicit error propagation

--- a/src/issue_workflow/services/claude_runner.py
+++ b/src/issue_workflow/services/claude_runner.py
@@ -121,7 +121,7 @@ class ClaudeRunner:
             cmd,
             cwd=cwd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             text=True,
         )
 

--- a/tests/unit/test_claude_runner.py
+++ b/tests/unit/test_claude_runner.py
@@ -363,6 +363,21 @@ class TestClaudeRunnerVerbose:
         callback.assert_not_called()
         assert result.exit_code == 0
 
+    @patch("issue_workflow.services.claude_runner.subprocess.Popen")
+    def test_verbose_uses_devnull_for_stderr(self, mock_popen: MagicMock) -> None:
+        """Test verbose mode uses subprocess.DEVNULL for stderr to prevent deadlock."""
+        mock_process = MagicMock()
+        mock_process.stdout = iter([json.dumps({"type": "result", "subtype": "success"}) + "\n"])
+        mock_process.wait.return_value = 0
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        runner = ClaudeRunner()
+        runner.run("prompt", verbose=True)
+
+        call_kwargs = mock_popen.call_args
+        assert call_kwargs.kwargs.get("stderr") == subprocess.DEVNULL
+
     @patch("issue_workflow.services.claude_runner.time.monotonic")
     @patch("issue_workflow.services.claude_runner.subprocess.Popen")
     def test_verbose_wait_uses_remaining_timeout(


### PR DESCRIPTION
## Summary
Replace subprocess.PIPE with subprocess.DEVNULL for stderr in _run_verbose() to prevent potential deadlock when stderr buffer fills without being read. Adds test to verify DEVNULL is used for stderr in verbose mode.

Closes #110

## Test plan
- Verify the unit test `test_verbose_uses_devnull_for_stderr` passes and confirms DEVNULL is used
- Run existing verbose mode tests to ensure no regressions
- Manual testing of verbose mode operation

Generated with [Claude Code](https://claude.com/claude-code)