### PR TITLE
fix: implement atomic directory replacement in update_skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `update_skills` non-atomic directory replacement causing data loss on `copytree` failure (#111)
 - `_run_verbose()` deadlock risk from unread `stderr=subprocess.PIPE` (#110)
 - `AskUserQuestion` tool disallowed in non-interactive mode
 - PR creation incorrectly skipped when merged/closed PRs exist for same branch

--- a/src/issue_workflow/services/template.py
+++ b/src/issue_workflow/services/template.py
@@ -309,20 +309,21 @@ class TemplateService:
                 elif (
                     change.change_type == FileChangeType.UPDATED and change.source_path is not None
                 ):
-                    target_removed = False
+                    temp_path = change.path.with_suffix(".new")
+                    backup_path = change.path.with_suffix(".bak")
                     try:
-                        shutil.rmtree(change.path)
-                        target_removed = True
-                        shutil.copytree(change.source_path, change.path)
+                        shutil.copytree(change.source_path, temp_path)
+                        change.path.rename(backup_path)
+                        try:
+                            temp_path.rename(change.path)
+                        except OSError:
+                            backup_path.rename(change.path)
+                            raise
+                        shutil.rmtree(backup_path)
                     except OSError as e:
-                        if target_removed:
-                            error_msg = (
-                                f"{e} (WARNING: Original directory was removed "
-                                "but new version could not be copied)"
-                            )
-                        else:
-                            error_msg = str(e)
-                        errors.append((change.path, error_msg))
+                        if temp_path.exists():
+                            shutil.rmtree(temp_path, ignore_errors=True)
+                        errors.append((change.path, str(e)))
 
         return UpdateResult(
             skills_changes=changes,

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -472,10 +472,8 @@ class TestFileCmpErrorHandling:
             finally:
                 template_module.get_skills_source_dir = original_func
 
-    def test_skills_update_rmtree_copytree_failure_shows_data_loss_warning(
-        self, tmp_path: Path
-    ) -> None:
-        """Test that copytree failure after rmtree warns about data loss."""
+    def test_skills_update_copytree_failure_preserves_original(self, tmp_path: Path) -> None:
+        """Test that copytree failure preserves the original directory (#111)."""
         from unittest.mock import patch
 
         # Setup source with updated skill
@@ -505,13 +503,45 @@ class TestFileCmpErrorHandling:
         ):
             try:
                 result = service.update_skills(target_dir, dry_run=False)
-                # Should have recorded the error with data loss warning
                 assert result.has_errors
-                error_messages = [str(err) for _, err in result.errors]
-                # Should mention that original directory was removed (data loss warning)
-                assert any("removed" in msg.lower() for msg in error_messages)
+                # Original directory must be preserved (not deleted)
+                assert (skills_target / "existing-skill").exists()
+                assert (skills_target / "existing-skill" / "skill.md").read_text() == "# Old Skill"
             finally:
                 template_module.get_skills_source_dir = original_func
+
+    def test_skills_update_atomic_no_temp_dirs_after_success(self, tmp_path: Path) -> None:
+        """Test that no temp/backup directories remain after successful update (#111)."""
+        # Setup source with updated skill
+        source_dir = tmp_path / "source_package" / "skills"
+        source_dir.mkdir(parents=True)
+        (source_dir / "my-skill").mkdir()
+        (source_dir / "my-skill" / "skill.md").write_text("# Updated")
+
+        # Setup target with existing skill
+        target_dir = tmp_path / ".claude"
+        skills_target = target_dir / "skills"
+        (skills_target / "my-skill").mkdir(parents=True)
+        (skills_target / "my-skill" / "skill.md").write_text("# Old")
+
+        service = TemplateService()
+        import issue_workflow.services.template as template_module
+
+        original_func = template_module.get_skills_source_dir
+        template_module.get_skills_source_dir = lambda: source_dir
+
+        try:
+            result = service.update_skills(target_dir, dry_run=False)
+            assert not result.has_errors
+            # Updated content is in place
+            assert (skills_target / "my-skill" / "skill.md").read_text() == "# Updated"
+            # No temp or backup directories remain
+            temp_dirs = list(skills_target.glob("*.new"))
+            backup_dirs = list(skills_target.glob("*.bak"))
+            assert temp_dirs == []
+            assert backup_dirs == []
+        finally:
+            template_module.get_skills_source_dir = original_func
 
 
 class TestDircmpRecursive:


### PR DESCRIPTION
## Summary
- Replaces non-atomic rmtree+copytree pattern with safe atomic replacement using temporary and backup directories
- Ensures original directory is preserved if copytree fails, preventing data loss
- Improved error handling with cleanup of temporary directories on failure

Closes #111

## Test plan
- Update skills with copytree failure scenario - original directory should be preserved
- Update skills with successful operation - no temp/backup directories should remain
- Verify error messages are correctly recorded without data loss warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)